### PR TITLE
Update telegrinder dependency to new commit hash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-telegrinder = { git = "https://github.com/timoniq/telegrinder", rev = "c2a0d7f" }
+telegrinder = { git = "https://github.com/timoniq/telegrinder", rev = "544f5f6" }
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.6.5"


### PR DESCRIPTION
Updated the telegrinder dependency in pyproject.toml to point to commit 544f5f6. This ensures the project uses the latest changes or fixes from the repository.