### PR TITLE
Refactor language code variable and improve text handling

### DIFF
--- a/examples/custom_example.py
+++ b/examples/custom_example.py
@@ -13,7 +13,7 @@ from telepager import (
     PaginationMessage,
     TelepagerMessage,
     setup_empty_callback_data_handler,
-    static_texts_paginator
+    static_texts_paginator,
 )
 
 DATA = [f"This is a {i}th message!" for i in range(1, 1000)]
@@ -21,7 +21,7 @@ DATA = [f"This is a {i}th message!" for i in range(1, 1000)]
 api = API(token=Token.from_env())
 bot = Telegrinder(api)
 
-paginator = static_texts_paginator("static", "Messages:" ,DATA)
+paginator = static_texts_paginator("static", "Messages:", DATA)
 setup_empty_callback_data_handler(paginator, bot.dispatch)
 
 

--- a/examples/filtered.py
+++ b/examples/filtered.py
@@ -1,6 +1,7 @@
 """
 Here is the example of paginator with filtering and ordering
 """
+
 from telepager import FetcherIter, Line, NaivePageBuilder, Paginator, PaginatorSettings
 from telepager.flag import Ordering, Quality
 

--- a/telepager/design.py
+++ b/telepager/design.py
@@ -4,7 +4,7 @@ import typing
 from telegrinder import InlineButton, InlineKeyboard
 
 from .flag import ANY_QUALITY, FLAG_T
-from .i18n import PossibleTexts, DEFAULT_LANG_CODE
+from .i18n import PossibleTexts, DEFAULT_LANGUAGE_CODE
 from .manager import PageBook
 from .settings import PaginatorSettings
 from .structs import FORCE_FETCH_ALL, PaginationMessage
@@ -29,7 +29,7 @@ def add_ordering_buttons[T](
 
         current_keyboard.add(
             InlineButton(
-                text=f"{settings.i18n[PossibleTexts.ORDERING].get(language_code, DEFAULT_LANG_CODE)} ⬇️",
+                text=f"{settings.i18n[PossibleTexts.ORDERING].get(language_code, DEFAULT_LANGUAGE_CODE)} ⬇️",
                 callback_data=message,
                 callback_data_serializer=settings.serializer,
             )
@@ -41,7 +41,7 @@ def add_ordering_buttons[T](
 
         current_keyboard.add(
             InlineButton(
-                text=f"{settings.i18n[PossibleTexts.ORDERING].get(language_code, DEFAULT_LANG_CODE)} ⬆️",
+                text=f"{settings.i18n[PossibleTexts.ORDERING].get(language_code, DEFAULT_LANGUAGE_CODE)} ⬆️",
                 callback_data=message,
                 callback_data_serializer=settings.serializer,
             )
@@ -83,7 +83,7 @@ def add_filters_buttons[T](
 
         current_keyboard.add(
             InlineButton(
-                text=f"{settings.i18n[PossibleTexts.QUALITIES].get(language_code, DEFAULT_LANG_CODE)} ⬇️",
+                text=f"{settings.i18n[PossibleTexts.QUALITIES].get(language_code, DEFAULT_LANGUAGE_CODE)} ⬇️",
                 callback_data=message,
                 callback_data_serializer=settings.serializer,
             )
@@ -95,18 +95,18 @@ def add_filters_buttons[T](
 
         current_keyboard.add(
             InlineButton(
-                text=f"{settings.i18n[PossibleTexts.QUALITIES].get(language_code, DEFAULT_LANG_CODE)} ⬆️",
+                text=f"{settings.i18n[PossibleTexts.QUALITIES].get(language_code, DEFAULT_LANGUAGE_CODE)} ⬆️",
                 callback_data=message,
                 callback_data_serializer=settings.serializer,
             )
         ).row()
 
         if pagination_message.quality == ANY_QUALITY:
-            all_qualities_text = f"📍 {settings.i18n[PossibleTexts.ALL_QUALITIES].get(language_code, DEFAULT_LANG_CODE)}"
+            all_qualities_text = f"📍 {settings.i18n[PossibleTexts.ALL_QUALITIES].get(language_code, DEFAULT_LANGUAGE_CODE)}"
             all_qualities_callback_data = "empty"
             serializer = None
         else:
-            all_qualities_text = f"{settings.i18n[PossibleTexts.ALL_QUALITIES].get(language_code, DEFAULT_LANG_CODE)}"
+            all_qualities_text = f"{settings.i18n[PossibleTexts.ALL_QUALITIES].get(language_code, DEFAULT_LANGUAGE_CODE)}"
             all_qualities_callback_data = pagination_message.copy_with_changed_fields(
                 page=0,
                 quality=ANY_QUALITY,

--- a/telepager/i18n.py
+++ b/telepager/i18n.py
@@ -1,12 +1,12 @@
 import enum
 import typing
 
-type LANG_CODE = str
-type I18N_Text = str | typing.Callable[[LANG_CODE], str]
-DEFAULT_LANG_CODE = "en"
+type LANGUAGE_CODE = str
+type I18N_Text = str | typing.Callable[[LANGUAGE_CODE], str]
+DEFAULT_LANGUAGE_CODE = "en"
 
 
-def internationalize(text: I18N_Text, language_code: LANG_CODE) -> str:
+def internationalize(text: I18N_Text, language_code: LANGUAGE_CODE) -> str:
     if isinstance(text, str):
         return text
     return text(language_code)
@@ -24,4 +24,4 @@ DEFAULT_I18N = {
     PossibleTexts.ALL_QUALITIES: {"ru": "Все", "en": "All", "es": "Todos"},
 }
 
-type PaginatorInternalI18N = dict[PossibleTexts, dict[LANG_CODE, str]]
+type PaginatorInternalI18N = dict[PossibleTexts, dict[LANGUAGE_CODE, str]]

--- a/telepager/manager.py
+++ b/telepager/manager.py
@@ -102,12 +102,26 @@ class NaivePageBuilder[T](ABCPageBuilder[T]):
 
 
 class FormattingPageBuilder[T](ABCPageBuilder[T]):
-    def __init__(self, base_text: str, formatting_template_name: str) -> None:
+    def __init__(
+        self,
+        base_text: str,
+        formatting_template_name: str,
+        empty_page_format_text: str | None = None,
+    ) -> None:
         self.base_text = base_text
         self.formatting_template_name = formatting_template_name
 
+        self.empty_page_format_text = empty_page_format_text
+
     async def empty_page(self) -> Page:
-        return Page(self.base_text.strip(self.formatting_template_name))
+        if self.empty_page_format_text is None:
+            text = self.base_text.replace(self.formatting_template_name, str())
+        else:
+            text = self.base_text.format(
+                **{self.formatting_template_name: self.empty_page_format_text}
+            )
+
+        return Page(text)
 
     async def build_page(self, lines: list[Line[T]]) -> Page | None:
         if not lines:

--- a/telepager/paginator.py
+++ b/telepager/paginator.py
@@ -66,7 +66,7 @@ class Paginator[T]:
                 text=text,
                 reply_markup=keyboard.get_markup() if keyboard else None,
                 parse_mode=HTMLFormatter.PARSE_MODE,
-                **telegram_api_additional
+                **telegram_api_additional,
             )
             record.last_message_id_to_edit = result.unwrap().message_id
         else:
@@ -76,7 +76,7 @@ class Paginator[T]:
                 message_id=record.last_message_id_to_edit,
                 reply_markup=keyboard.get_markup() if keyboard else None,
                 parse_mode=HTMLFormatter.PARSE_MODE,
-                **telegram_api_additional
+                **telegram_api_additional,
             )
 
     async def _get_page_book(
@@ -186,7 +186,7 @@ class Paginator[T]:
                     chat_id=chat_id,
                     text=internationalize(empty_page_book_text, language_code),
                     parse_mode=HTMLFormatter.PARSE_MODE,
-                    **telegram_api_additional
+                    **telegram_api_additional,
                 )
             # if there is no pages for asked quality
             else:


### PR DESCRIPTION
Renamed LANG_CODE to LANGUAGE_CODE for clarity across the codebase. Adjusted handling of empty page text in FormattingPageBuilder for better flexibility. Minor corrections in examples and fixed formatting inconsistencies.