### PR TITLE
Fix placeholder replacement in empty_page method

### DIFF
--- a/telepager/manager.py
+++ b/telepager/manager.py
@@ -115,7 +115,7 @@ class FormattingPageBuilder[T](ABCPageBuilder[T]):
 
     async def empty_page(self) -> Page:
         if self.empty_page_format_text is None:
-            text = self.base_text.replace(self.formatting_template_name, str())
+            text = self.base_text.format(**{self.formatting_template_name: str()})
         else:
             text = self.base_text.format(
                 **{self.formatting_template_name: self.empty_page_format_text}


### PR DESCRIPTION
Corrected the logic for formatting the base text in the `empty_page` method to ensure placeholders are properly replaced. This resolves potential issues with displaying empty pages when no format text is provided.